### PR TITLE
Use Base.libblas_name for compatibility with Julia master

### DIFF
--- a/src/NeuralAttentionlib.jl
+++ b/src/NeuralAttentionlib.jl
@@ -9,6 +9,8 @@ import Adapt: adapt_structure, adapt
 
 import Base
 
+const libblas = Base.libblas_name
+
 export attention, generic_attention
 
 include("./utils.jl")

--- a/src/matmul/gemm.jl
+++ b/src/matmul/gemm.jl
@@ -13,7 +13,7 @@ for (gemm, elty) in NNlib.gemm_datatype_mappings
             ptrB::Ptr{$elty}, ldb::Int, beta::($elty),
             ptrC::Ptr{$elty}, ldc::Int)
 
-            ccall((BLAS.@blasfunc($gemm), BLAS.libblas), Nothing,
+            ccall((BLAS.@blasfunc($gemm), libblas), Nothing,
                   (Ref{UInt8}, Ref{UInt8}, Ref{BLAS.BlasInt}, Ref{BLAS.BlasInt}, Ref{BLAS.BlasInt},
                    Ref{$elty}, Ptr{$elty}, Ref{BLAS.BlasInt},
                    Ptr{$elty}, Ref{BLAS.BlasInt}, Ref{$elty},


### PR DESCRIPTION
Similar to https://github.com/FluxML/NNlib.jl/pull/396#issuecomment-1058364057 - `libblas` has been phased out and so `Base.libblas_name` is the way to maintain compatibility going forward. Encountered this while testing on Julia master 😅