### PR TITLE
Update deps version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,7 @@ FuncTransforms = "0.1"
 GPUArrays = "10"
 GPUArraysCore = "0.1"
 NNlib = "0.9"
-Static = "0.7, 0.8"
+Static = "0.7, 0.8, 1"
 Zygote = "0.6"
 julia = "1.10"
 


### PR DESCRIPTION
I get compatibility issues with newer versions of other packages in the same julia environment as Transformer.jl. I traced them down to the other packages (DifferentialEquations.jl in this case) requiring newer versions of the Static package, which NeuralAttentionlib.jl does not allow.